### PR TITLE
Add GADE Union contact line on homepage

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -30,6 +30,8 @@ social: true # includes social icons at the bottom of the page
 
 <small>🚀 Referral(内推） Available — <a href="/blog/2025/bytedance-referral/">Details here →</a></small>
 
+<small>如果你需要工业级基准数据集，请联系 <a href="https://gadeunion.com/" target="_blank" rel="noopener noreferrer">GADE Union</a>。</small>
+
 ## Education
 
 - 2018/9-2020/6; Master in Data Science @ New York University


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a single line below the referral notice on the homepage (About page at `/`) linking to [https://gadeunion.com/](https://gadeunion.com/) for industrial-grade benchmark datasets.

The link opens in a new tab with `rel="noopener noreferrer"` for security.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d25c9299-94cc-4e83-857e-c0f1f2806c54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d25c9299-94cc-4e83-857e-c0f1f2806c54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

